### PR TITLE
More exception details returned to the caller

### DIFF
--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcOperation.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcOperation.cs
@@ -149,7 +149,7 @@ namespace WampSharp.V2.Rpc
         protected static WampRpcRuntimeException ConvertExceptionToRuntimeException(Exception exception)
         {
             // TODO: Maybe try a different implementation.
-            return new WampRpcRuntimeException(exception.Message);
+            return new WampRpcRuntimeException(exception.ToString());
         }
     }
 }


### PR DESCRIPTION
When the caller was getting an exception back from the callee, it was confusing where the exception was being throw.  Adding the stack trace to the details of the reject message would be helpful for tracing the source of the error.
